### PR TITLE
Fixing Circle GitHub release environment variable typo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: echo 'export GITHUB_ORGANIZATION=$CIRCLE_PROJECT_USERNAME' >> $BASH_ENV
-      - run: echo 'export GITHUB_REPOSITORY=$CIRCLE_PROJECT_USERNAME' >> $BASH_ENV
+      - run: echo 'export GITHUB_REPOSITORY=$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
       - run: echo 'export DOCKER_BASE_TAG=$CIRCLE_TAG' >> $BASH_ENV
       - *npm_release
       - *github_release


### PR DESCRIPTION
This seems to be the final bug that was preventing the `github_release` step from working.