### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ references:
       name: GitHub release
       command: |
         git fetch --tags
-        curl -O https://raw.githubusercontent.com/reactiveops/release.sh/v0.0.2/release
+        curl -O https://raw.githubusercontent.com/FairwindsOps/release.sh/v0.0.2/release
         /bin/bash release
 
   build_docker_tags: &build_docker_tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to contribute
 
-Issues, whether bugs, tasks, or feature requests are essential for keeping rok8s-scripts (and ReactiveOps in general) great.
+Issues, whether bugs, tasks, or feature requests are essential for keeping rok8s-scripts (and Fairwinds in general) great.
 We believe it should be as easy as possible to contribute changes that
 get things working in your environment. There are a few guidelines that we
 need contributors to follow so that we can have a chance of keeping on

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This is a set of opinionated scripts for managing application development and deployment lifecycle using Kubernetes. These simplify secure secrets management, environment specific config, Docker build caching, and much more. The opinionated nature of the scripts reflects the collective experience and observed best-practices that ReactiveOps has accumulated.
+This is a set of opinionated scripts for managing application development and deployment lifecycle using Kubernetes. These simplify secure secrets management, environment specific config, Docker build caching, and much more. The opinionated nature of the scripts reflects the collective experience and observed best-practices that Fairwinds has accumulated.
 
 ## Guiding Principles
 
@@ -15,7 +15,7 @@ It should be relatively trivial to take an existing Dockerized application and c
 When introducing a new feature to rok8s-scripts, it should be backward-compatible.  If it might break something, we prefer to contain it inside of an environment variable feature flag in order to make the feature optional. If this is not possible, sufficient care should be taken to notify customers and increment version accordingly.
 
 **Scope**
-As maintainers of rok8s-scripts, ReactiveOps is not in the business of catering to every single hand-crafted bespoke pipeline in existence. This means that some changes may be out of scope for the intended purpose. The intended purpose is to build, push, and deploy containers.
+As maintainers of rok8s-scripts, Fairwinds is not in the business of catering to every single hand-crafted bespoke pipeline in existence. This means that some changes may be out of scope for the intended purpose. The intended purpose is to build, push, and deploy containers.
 
 **Pull Requests Welcom**
 Please don't hesistate to reach out and file a PR or an Issue if you would like to see something implemented. See [CONTRIBUTING](CONTRIBUTING.md)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 docs-index:
 	cat README.md \
-	| sed -E 's/\[(.*)\]\(([^\/]*\.md)\)/[\1](https:\/\/github.com\/reactiveops\/rok8s-scripts\/tree\/master\/\2)/g' \
+	| sed -E 's/\[(.*)\]\(([^\/]*\.md)\)/[\1](https:\/\/github.com\/FairwindsOps\/rok8s-scripts\/tree\/master\/\2)/g' \
 	| sed -E 's/\[(.*)\]\(\/*docs\/(.*)\)/[\1](\2)/g' \
-	| sed -E 's/\[(.*)\]\((\/.*)\)/[\1](https:\/\/github.com\/reactiveops\/rok8s-scripts\/tree\/master\2)/g' \
+	| sed -E 's/\[(.*)\]\((\/.*)\)/[\1](https:\/\/github.com\/FairwindsOps\/rok8s-scripts\/tree\/master\2)/g' \
 	> docs/index.md
 orb-validate:
 	circleci config pack orb/ > orb.yml

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 [![Version][version-image]][version-link] [![CircleCI][circleci-image]][circleci-link]
 
 [version-image]: https://img.shields.io/static/v1.svg?label=Version&message=8.1.0&color=239922
-[version-link]: https://github.com/reactiveops/rok8s-scripts/releases
-[circleci-image]: https://circleci.com/gh/reactiveops/rok8s-scripts.svg?style=svg
-[circleci-link]: https://circleci.com/gh/reactiveops/rok8s-scripts
+[version-link]: https://github.com/FairwindsOps/rok8s-scripts/releases
+[circleci-image]: https://circleci.com/gh/FairwindsOps/rok8s-scripts.svg?style=svg
+[circleci-link]: https://circleci.com/gh/FairwindsOps/rok8s-scripts
 
 # rok8s-scripts
 
 rok8s-scripts is a framework for building GitOps workflows with Docker and Kubernetes.
 By adding rok8s-scripts to your CI/CD pipeline, you can build, push, and deploy your applications using the
-set of best practices we've built at ReactiveOps.
+set of best practices we've built at Fairwinds.
 
 In addition to building Docker images and deploying them to Kubernetes, rok8s-scripts is a great way to handle
 secure secrets management, environment specific configuration, Docker build caching, and much more.
 
-**Want to learn more?** ReactiveOps holds [office hours on Zoom](https://zoom.us/j/242508205) the first Friday of every month, at 12pm Eastern. You can also reach out via email at `opensource@fairwinds.com`
+**Want to learn more?** Fairwinds holds [office hours on Zoom](https://zoom.us/j/242508205) the first Friday of every month, at 12pm Eastern. You can also reach out via email at `opensource@fairwinds.com`
 
 ### Quickstart
 To help you get started quickly, we've built a [minimal example](/examples/minimal)
@@ -82,7 +82,7 @@ In this case, go ahead and pin to a major version such as `v8-alpine`
 
 ## Orbs
 
-CircleCI has introduced the concept of reusable config in the form of [Orbs](https://circleci.com/orbs/).  As of rok8s-scripts v9.0.0, ReactiveOps publishes an orb called `reactiveops/rok8s-scripts` in order to provide easier configuration inside of CircleCI.
+CircleCI has introduced the concept of reusable config in the form of [Orbs](https://circleci.com/orbs/).  As of rok8s-scripts v9.0.0, Fairwinds publishes an orb called `fairwinds/rok8s-scripts` in order to provide easier configuration inside of CircleCI.
 
 ## Further Reading
 

--- a/bin/helm-example-config
+++ b/bin/helm-example-config
@@ -20,7 +20,7 @@ fi
 
 # shellcheck disable=2086
 cat <<EOT >> $CONFIG
-# Configuration for https://github.com/reactiveops/rok8s-scripts
+# Configuration for https://github.com/FairwindsOps/rok8s-scripts
 
 # Dockerfile to build
 DOCKERFILE='Dockerfile'

--- a/bin/k8s-example-config
+++ b/bin/k8s-example-config
@@ -19,7 +19,7 @@ if test -f $CONFIG ; then
 fi
 
 cat <<EOT >> $CONFIG
-# Configuration for https://github.com/reactiveops/rok8s-scripts
+# Configuration for https://github.com/FairwindsOps/rok8s-scripts
 
 # Dockerfile to build
 DOCKERFILE='Dockerfile'

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,23 @@
 [![Version][version-image]][version-link] [![CircleCI][circleci-image]][circleci-link]
 
 [version-image]: https://img.shields.io/static/v1.svg?label=Version&message=8.1.0&color=239922
-[version-link]: https://github.com/reactiveops/rok8s-scripts/releases
-[circleci-image]: https://circleci.com/gh/reactiveops/rok8s-scripts.svg?style=svg
-[circleci-link]: https://circleci.com/gh/reactiveops/rok8s-scripts
+[version-link]: https://github.com/FairwindsOps/rok8s-scripts/releases
+[circleci-image]: https://circleci.com/gh/FairwindsOps/rok8s-scripts.svg?style=svg
+[circleci-link]: https://circleci.com/gh/FairwindsOps/rok8s-scripts
 
 # rok8s-scripts
 
 rok8s-scripts is a framework for building GitOps workflows with Docker and Kubernetes.
 By adding rok8s-scripts to your CI/CD pipeline, you can build, push, and deploy your applications using the
-set of best practices we've built at ReactiveOps.
+set of best practices we've built at Fairwinds.
 
 In addition to building Docker images and deploying them to Kubernetes, rok8s-scripts is a great way to handle
 secure secrets management, environment specific configuration, Docker build caching, and much more.
 
-**Want to learn more?** ReactiveOps holds [office hours on Zoom](https://zoom.us/j/242508205) the first Friday of every month, at 12pm Eastern. You can also reach out via email at `opensource@fairwinds.com`
+**Want to learn more?** Fairwinds holds [office hours on Zoom](https://zoom.us/j/242508205) the first Friday of every month, at 12pm Eastern. You can also reach out via email at `opensource@fairwinds.com`
 
 ### Quickstart
-To help you get started quickly, we've built a [minimal example](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/minimal)
+To help you get started quickly, we've built a [minimal example](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/minimal)
 that shows how to use rok8s-scripts to build Docker images and deploy to Kubernetes
 using Circle CI. This example will serve as a helpful introduction regardless of your CI platform.
 
@@ -39,20 +39,20 @@ rok8s-scripts is a great way to deploy your chart to staging and production
 ## Examples
 
 rok8s-scripts is designed to work well with a wide variety of use cases and environments.
-There are many valid ways to configure CI pipelines, but to help you get started, we've included a variety of [examples](https://github.com/reactiveops/rok8s-scripts/tree/master/examples) in this repository.
+There are many valid ways to configure CI pipelines, but to help you get started, we've included a variety of [examples](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples) in this repository.
 
 ### CI Platforms
-- [Bitbucket Pipelines](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/bitbucket-pipelines.yml)
-- [CircleCI](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/.circleci/config.yml)
-- [GitLab CI](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/.gitlab-ci.yml)
-- [Jenkins](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/Jenkinsfile)
+- [Bitbucket Pipelines](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/ci/bitbucket-pipelines.yml)
+- [CircleCI](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/ci/.circleci/config.yml)
+- [GitLab CI](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/ci/.gitlab-ci.yml)
+- [Jenkins](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/ci/Jenkinsfile)
 
 ### Miscellaneous examples
-- [External secrets manager](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/external-secrets-manager)
-- [SOPS secrets](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/sops-secrets) - Shows how to use [sops](https://github.com/mozilla/sops) with rok8s-scripts
-- [Using Helm](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/helm) - We recommend using Helm to manage your deployments
-- [Optional components](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/optional-components) - Turn components (e.g. Horizontal Pod Audoscaler) on and off depending on whether you're deploying to staging or production
-- [Production ready](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/production-ready) - Includes a number of recommended production features
+- [External secrets manager](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/external-secrets-manager)
+- [SOPS secrets](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/sops-secrets) - Shows how to use [sops](https://github.com/mozilla/sops) with rok8s-scripts
+- [Using Helm](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/helm) - We recommend using Helm to manage your deployments
+- [Optional components](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/optional-components) - Turn components (e.g. Horizontal Pod Audoscaler) on and off depending on whether you're deploying to staging or production
+- [Production ready](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/production-ready) - Includes a number of recommended production features
 
 ## CI Images
 
@@ -82,7 +82,7 @@ In this case, go ahead and pin to a major version such as `v8-alpine`
 
 ## Orbs
 
-CircleCI has introduced the concept of reusable config in the form of [Orbs](https://circleci.com/orbs/).  As of rok8s-scripts v9.0.0, ReactiveOps publishes an orb called `reactiveops/rok8s-scripts` in order to provide easier configuration inside of CircleCI.
+CircleCI has introduced the concept of reusable config in the form of [Orbs](https://circleci.com/orbs/).  As of rok8s-scripts v9.0.0, Fairwinds publishes an orb called `fairwinds/rok8s-scripts` in order to provide easier configuration inside of CircleCI.
 
 ## Further Reading
 
@@ -96,8 +96,8 @@ CircleCI has introduced the concept of reusable config in the form of [Orbs](htt
 - [Google Cloud](gcp.md)
 
 ### Contributing
-- [Code of Conduct](https://github.com/reactiveops/rok8s-scripts/tree/master/CODE_OF_CONDUCT.md)
-- [Roadmap](https://github.com/reactiveops/rok8s-scripts/tree/master/ROADMAP.md)
+- [Code of Conduct](https://github.com/FairwindsOps/rok8s-scripts/tree/master/CODE_OF_CONDUCT.md)
+- [Roadmap](https://github.com/FairwindsOps/rok8s-scripts/tree/master/ROADMAP.md)
 - [Releasing New Versions of rok8s-scripts](releasing.md)
 - [Changelog](https://github.com/FairwindsOps/rok8s-scripts/releases)
 

--- a/docs/kubernetes_auth.md
+++ b/docs/kubernetes_auth.md
@@ -53,7 +53,7 @@ kubectl create clusterrolebinding rok8s-scripts \
 ```
 
 #### Safer permissions
-> The examples below use [rbac-manager](https://github.com/reactiveops/rbac-manager)
+> The examples below use [rbac-manager](https://github.com/FairwindsOps/rbac-manager)
 > to simplify the permissions model
 
 One common pattern is to only grant `cluster-admin` permissions on namespaces that

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -10,7 +10,7 @@ There are two ways to use this:
 * `. get-secrets` - this will allow you to use the variables as environment variables
 * As part of `k8s-deploy-secrets` when you set `EXTERNAL_SECRETS_K8S_NAME`.  This will create a secret in the k8s cluster with all of the secrets from the secret store that you listed.
 
-There is an example [here](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/external-secrets-manager).
+There is an example [here](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/external-secrets-manager).
 
 ## Encrypted Secrets With Sops
 Sops and rok8s-scripts can provide a powerful solution to encrypted secret management. This enables you to keep your secrets in source control and track changes to those secrets along with the rest of your Kubernetes configuration. All of this is powered with cloud based KMS from either AWS or GCP. To access secrets, users need access to both your Git repository and appropriate IAM credentials for KMS.
@@ -19,7 +19,7 @@ Using an [AWS KMS](https://aws.amazon.com/kms/) ARN or [Google KMS](https://clou
 
 Whenever encrypting data, `sops` requires credentials for the appropriate
 cloud provider (GCP or AWS). You can read more about `sops` usage [here](https://github.com/mozilla/sops#usage). Full examples of sops usage with rok8s-scripts can be
-[found here](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/sops-secrets).
+[found here](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples/sops-secrets).
 
 The examples below will use GCP KMS, but the process is very similar when using AWS KMS.
 

--- a/docs/without_helm.md
+++ b/docs/without_helm.md
@@ -44,7 +44,7 @@ This full configuration could be deployed with the following rok8s-scripts comma
 k8s-deploy-and-verify -f deploy/development.config
 ```
 
-More indepth examples are available in the [examples directory](https://github.com/reactiveops/rok8s-scripts/tree/master/examples).
+More indepth examples are available in the [examples directory](https://github.com/FairwindsOps/rok8s-scripts/tree/master/examples).
 
 ## Credentials
 See [Kubernetes auth](kubernetes_auth.md) to learn how to grant your CI pipeline access to your Kubernetes cluster

--- a/examples/external-secrets-manager/package.json
+++ b/examples/external-secrets-manager/package.json
@@ -4,9 +4,9 @@
   "description": "Example app deployment with rok8s-scripts",
   "repository": {
     "type": "git",
-    "url": "+https://github.com/reactiveops/rok8s-scripts.git"
+    "url": "+https://github.com/FairwindsOps/rok8s-scripts.git"
   },
-  "author": "ReactiveOps",
+  "author": "Fairwinds",
   "license": "Apache-2.0",
   "dependencies": {
      "rok8s-scripts": "*"

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -24,7 +24,7 @@ to ensure rok8s-scripts and its dependencies are all available during the build 
 
 * Run the following to copy this directory to a new git repository:
 ```
-git clone https://github.com/reactiveops/rok8s-scripts
+git clone https://github.com/FairwindsOps/rok8s-scripts
 cp -r rok8s-scripts/examples/minimal rok8s-scripts-test
 cd rok8s-scripts-test
 git init

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -4,9 +4,9 @@
   "description": "Example app deployment with rok8s-scripts",
   "repository": {
     "type": "git",
-    "url": "+https://github.com/reactiveops/rok8s-scripts.git"
+    "url": "+https://github.com/FairwindsOps/rok8s-scripts.git"
   },
-  "author": "ReactiveOps",
+  "author": "Fairwinds",
   "license": "Apache-2.0",
   "scripts": {
     "start": "node server.js"

--- a/examples/production-ready/package.json
+++ b/examples/production-ready/package.json
@@ -4,9 +4,9 @@
   "description": "Example app deployment with rok8s-scripts",
   "repository": {
     "type": "git",
-    "url": "+https://github.com/reactiveops/rok8s-scripts.git"
+    "url": "+https://github.com/FairwindsOps/rok8s-scripts.git"
   },
-  "author": "ReactiveOps",
+  "author": "Fairwinds",
   "license": "Apache-2.0",
   "dependencies": {
      "rok8s-scripts": "*"

--- a/examples/sops-secrets/package.json
+++ b/examples/sops-secrets/package.json
@@ -4,9 +4,9 @@
   "description": "Example app deployment with rok8s-scripts",
   "repository": {
     "type": "git",
-    "url": "+https://github.com/reactiveops/rok8s-scripts.git"
+    "url": "+https://github.com/FairwindsOps/rok8s-scripts.git"
   },
-  "author": "ReactiveOps",
+  "author": "Fairwinds",
   "license": "Apache-2.0",
   "dependencies": {
      "rok8s-scripts": "*"


### PR DESCRIPTION
Remaining mentions: 
```
./orb/jobs.yml:      - image: quay.io/reactiveops/ci-images:<<parameters.version>>
./examples/ci/.gitlab-ci.yml:image: quay.io/reactiveops/ci-images:v9-alpine
./examples/ci/bitbucket-pipelines.yml:image: quay.io/reactiveops/ci-images:v8-stretch
./examples/ci/.circleci/config.yml:      - image: quay.io/reactiveops/ci-images:v9-alpine
./examples/ci/.circleci/config.yml:      - image: quay.io/reactiveops/ci-images:v9-alpine
./examples/minimal/README.md:We also use the rok8s-scripts CI image, `quay.io/reactiveops/ci-images:v9-stretch`,
./examples/minimal/.circleci/config.yml:      - image: quay.io/reactiveops/ci-images:v9.0-stretch
./examples/minimal/.circleci/config.yml:      - image: quay.io/reactiveops/ci-images:v9.0-stretch
./README.md:We currently include CI Images based on Alpine and Debian Stretch as our recommended starting points. The latest Debian Stretch release can be pulled from `quay.io/reactiveops/ci-images:v9-stretch`. A full list of image tags is available on our [Quay repository](https://quay.io/repository/reactiveops/ci-images).
./docs/kubernetes_auth.md:apiVersion: rbacmanager.reactiveops.io/v1beta1
./docs/kubernetes_auth.md:apiVersion: rbacmanager.reactiveops.io/v1beta1
./docs/index.md:We currently include CI Images based on Alpine and Debian Stretch as our recommended starting points. The latest Debian Stretch release can be pulled from `quay.io/reactiveops/ci-images:v9-stretch`. A full list of image tags is available on our [Quay repository](https://quay.io/repository/reactiveops/ci-images).
./.circleci/config.yml:      command: docker login -u="reactiveops+circleci" -p="${QUAY_TOKEN}" quay.io
./.circleci/config.yml:          docker build -f ci-images/${docker_base}/Dockerfile -t quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-${docker_base} .
./.circleci/config.yml:            docker tag quay.io/reactiveops/ci-images:{$DOCKER_BASE_TAG,$DOCKER_MAJOR_TAG}-${docker_base}
./.circleci/config.yml:            docker tag quay.io/reactiveops/ci-images:{$DOCKER_BASE_TAG,$DOCKER_MINOR_TAG}-${docker_base}
./.circleci/config.yml:            docker push quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-${docker_base}
./.circleci/config.yml:            docker push quay.io/reactiveops/ci-images:$DOCKER_MAJOR_TAG-${docker_base}
./.circleci/config.yml:            docker push quay.io/reactiveops/ci-images:$DOCKER_MINOR_TAG-${docker_base}
./.circleci/config.yml:            docker push quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-${docker_base}
```