### PR TITLE
bump sops to latest version

### DIFF
--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -34,7 +34,7 @@ fi
 
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.12.7}"
 HELM_VERSION="${HELM_VERSION:-v2.13.0}"
-SOPS_VERSION="${SOPS_VERSION:-3.2.0}"
+SOPS_VERSION="${SOPS_VERSION:-3.3.1}"
 
 # make sure sudo is installed
 if ! hash sudo 2>/dev/null; then


### PR DESCRIPTION
Sops has had a number of changes since 3.20; notably, you can use AWS KMS alias ARNs to references KMS keys now. This allows for somewhat simpler configuration of CI pipelines that are repeated across different environments; the region id or account in the provided KMS ARN would be all that needs to change in such scenarios. 