### PR TITLE
Allow the orb e2e test to store test results

### DIFF
--- a/orb/jobs/kubernetes_e2e_tests.yml
+++ b/orb/jobs/kubernetes_e2e_tests.yml
@@ -41,6 +41,12 @@ parameters:
     type: boolean
     description: "Enables docker_layer_caching on remote docker. Requires a paid plan."
     default: true
+  store-test-results:
+    description: |
+      The location to store test results. This path will be used in the command runner as well as
+      the executor, so it is recommended that you choose something like /tmp/test-results
+    type: string
+    default: ""
 executor: <<parameters.executor>>
 steps:
   - checkout
@@ -57,3 +63,14 @@ steps:
   - e2e_run_script:
       pre_script: << parameters.pre_script >>
       script: << parameters.script >>
+  - when:
+      condition: << parameters.store-test-results >>
+      steps:
+        - run:
+            name: Retrieve Test Output From Command Runner
+            when: always
+            command: |
+              mkdir -p $(dirname "<< parameters.store-test-results >>")
+              docker cp e2e-command-runner:<< parameters.store-test-results >> << parameters.store-test-results >>
+        - store_test_results:
+            path: << parameters.store-test-results >>


### PR DESCRIPTION
This allows the generation of test files from your e2e tests. It will copy them out of the command runner into the main executor and then save them as tests results in Circle.