### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb/@orb.yml
+++ b/orb/@orb.yml
@@ -7,4 +7,4 @@ description: |
 
 display:
   home_url: https://fairwindsops.github.io/rok8s-scripts/
-  source_url: https://github.com/fairwindsops/rok8s-scripts
+  source_url: https://github.com/FairwindsOps/rok8s-scripts

--- a/orb/@orb.yml
+++ b/orb/@orb.yml
@@ -5,4 +5,6 @@ description: |
 
   In addition to building Docker images and deploying them to Kubernetes, rok8s-scripts is a great way to handle secure secrets management, environment specific configuration, Docker build caching, and much more.
 
-  Repo: https://github.com/fairwindsops/rok8s-scripts"
+display:
+  home_url: https://fairwindsops.github.io/rok8s-scripts/
+  source_url: https://github.com/fairwindsops/rok8s-scripts


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.