### PR TITLE
Add limited helm2 support to rok8s11

### DIFF
--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -1,10 +1,10 @@
 #!/bin/bash
 
+# shellcheck disable=SC2086
+
 set -eo pipefail
 
 . k8s-read-config
-
-# shellcheck disable=SC2086
 
 # Set a CI_REF from branch or tag
 CI_REF="${CI_TAG}"
@@ -55,10 +55,14 @@ format_multiple_values_files() {
   done
   echo "${formatted_files%?}" )
 }
-
 helm_upgrade() {
   # shellcheck disable=SC2086
-  helm upgrade --install "${CHART_RELEASE_NAME}" \
+  if [ "$ROK8S_USE_HELM2" ]; then
+      helmCmd="helm2"
+  else
+      helmCmd="helm"
+  fi
+  "$helmCmd" upgrade --install "${CHART_RELEASE_NAME}" \
     "${CHART_PATH}" \
     -f "${CHART_VALUES}" \
     --set image.tag="${CI_SHA1}" \
@@ -72,6 +76,10 @@ helm_upgrade() {
 }
 
 helm_template() {
+  if [ "$ROK8S_USE_HELM2" ]; then
+      rok8s_echo "Template does not support helm2"
+      exit 1
+  fi
   temp_dir="${ROK8S_TMP}/remote_repo"
   if [ -n "${HELM_REPO_URLS}" ]; then
     helm fetch --untar --untardir "${temp_dir}" "${CHART_PATH}"

--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -57,7 +57,7 @@ format_multiple_values_files() {
 }
 helm_upgrade() {
   # shellcheck disable=SC2086
-  if [ "$ROK8S_USE_HELM2" ]; then
+  if [ "$ROK8S_USE_HELM2" == "true" ]; then
       helmCmd="helm2"
   else
       helmCmd="helm"

--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -34,6 +34,7 @@ fi
 
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.16.8}"
 HELM_VERSION="${HELM_VERSION:-v3.2.0}"
+HELM2_VERSION="${HELM2_VERSION:-v2.16.8}"
 SOPS_VERSION="${SOPS_VERSION:-v3.5.0}"
 
 # make sure sudo is installed
@@ -111,7 +112,7 @@ if ! hash sops 2>/dev/null; then
   chmod +x "${ROK8S_INSTALL_PATH}/sops"
 fi
 
-# make sure helm is installed
+# make sure helm 3 is installed
 if ! hash helm 2>/dev/null; then
   echo Installing helm...
   mkdir "${ROK8S_INSTALL_PATH}/helm-tmp"
@@ -119,6 +120,16 @@ if ! hash helm 2>/dev/null; then
   mv "${ROK8S_INSTALL_PATH}/helm-tmp/linux-amd64/helm" "${ROK8S_INSTALL_PATH}/helm"
   chmod +x "${ROK8S_INSTALL_PATH}/helm"
   rm -rf "${ROK8S_INSTALL_PATH}/helm-tmp"
+fi
+
+# make sure helm2 is installed
+if ! hash helm 2>/dev/null; then
+  echo Installing helm2...
+  mkdir "${ROK8S_INSTALL_PATH}/helm2-tmp"
+  curl "https://get.helm.sh/helm-${HELM2_VERSION}-linux-amd64.tar.gz" | tar xzvf - -C "${ROK8S_INSTALL_PATH}/helm2-tmp"
+  mv "${ROK8S_INSTALL_PATH}/helm-tmp/linux-amd64/helm" "${ROK8S_INSTALL_PATH}/helm2"
+  chmod +x "${ROK8S_INSTALL_PATH}/helm2"
+  rm -rf "${ROK8S_INSTALL_PATH}/helm2-tmp"
 fi
 
 # make sure kubeval is installed

--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -127,7 +127,7 @@ if ! hash helm2 2>/dev/null; then
   echo Installing helm2...
   mkdir "${ROK8S_INSTALL_PATH}/helm2-tmp"
   curl "https://get.helm.sh/helm-${HELM2_VERSION}-linux-amd64.tar.gz" | tar xzvf - -C "${ROK8S_INSTALL_PATH}/helm2-tmp"
-  mv "${ROK8S_INSTALL_PATH}/helm-tmp/linux-amd64/helm" "${ROK8S_INSTALL_PATH}/helm2"
+  mv "${ROK8S_INSTALL_PATH}/helm2-tmp/linux-amd64/helm" "${ROK8S_INSTALL_PATH}/helm2"
   chmod +x "${ROK8S_INSTALL_PATH}/helm2"
   rm -rf "${ROK8S_INSTALL_PATH}/helm2-tmp"
 fi

--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -123,7 +123,7 @@ if ! hash helm 2>/dev/null; then
 fi
 
 # make sure helm2 is installed
-if ! hash helm 2>/dev/null; then
+if ! hash helm2 2>/dev/null; then
   echo Installing helm2...
   mkdir "${ROK8S_INSTALL_PATH}/helm2-tmp"
   curl "https://get.helm.sh/helm-${HELM2_VERSION}-linux-amd64.tar.gz" | tar xzvf - -C "${ROK8S_INSTALL_PATH}/helm2-tmp"


### PR DESCRIPTION
Installs helm2 as the binary `helm2` and allows setting a variable to use that instead.

This should allow setting a few variables that will enable the use of helm2 only for deployment purposes.

```
DISABLE_HELM_2_DETECTION=true
ROK8S_USE_HELM2=true
HELM_TIMEOUTS=('400')
```

This will require setting HELM_TIMEOUTS for each chart since the format is different in Helm2 and the defaults will not work.

I propose that if we are going to merge this, we make it an un-documented feature