### PR TITLE
add option to e2e-tests to store artifacts

### DIFF
--- a/orb/jobs/kubernetes_e2e_tests.yml
+++ b/orb/jobs/kubernetes_e2e_tests.yml
@@ -47,6 +47,12 @@ parameters:
       the executor, so it is recommended that you choose something like /tmp/test-results
     type: string
     default: ""
+  store-artifacts:
+    description: |
+      The location to store artifacts from. This path will be used in the command runner as well as
+      the executor, so it is recommended that you choose something like /tmp/output
+    type: string
+    default: ""
   attach-workspace:
     description: |
       If true, the attach_workspace step will be run before any other steps.
@@ -89,3 +95,14 @@ steps:
               docker cp e2e-command-runner:<< parameters.store-test-results >> << parameters.store-test-results >>
         - store_test_results:
             path: << parameters.store-test-results >>
+  - when:
+      condition: << parameters.store-artifacts >>
+      steps:
+        - run:
+            name: Retrieve Artifacts From Command Runner
+            when: always
+            command: |
+              mkdir -p $(dirname "<< parameters.store-artifacts >>")
+              docker cp e2e-command-runner:<< parameters.store-artifacts >> << parameters.store-artifacts >>
+        - store_artifacts:
+            path: << parameters.store-artifacts >>


### PR DESCRIPTION
This was a quick add. But there have been times using the e2e tests job that I've wanted to save off some files for debugging purposes. This would allow that.