### PR TITLE
Pull from main in addition to master for Docker build

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -29,6 +29,7 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
     echo "Checking for existing cache image for target[${CACHE_TARGET}]..."
     docker pull "${TARGET_IMAGE}:${TARGET_TAG}" || true
     docker pull "${TARGET_IMAGE}:cache-master-${CACHE_TARGET}" || true
+    docker pull "${TARGET_IMAGE}:cache-main-${CACHE_TARGET}" || true
 
     echo "Building Dockerfile target[${CACHE_TARGET}]..."
     # shellcheck disable=2086
@@ -38,6 +39,7 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
       ${ROK8S_DOCKER_BUILD_EXTRAARGS} \
       --cache-from "${TARGET_IMAGE}:${TARGET_TAG}" \
       --cache-from "${TARGET_IMAGE}:cache-master-${CACHE_TARGET}" \
+      --cache-from "${TARGET_IMAGE}:cache-main-${CACHE_TARGET}" \
       "${BASEDIR}"
     CACHE_FROM_TARGETS="${CACHE_FROM_TARGETS} --cache-from ${TARGET_IMAGE}:${TARGET_TAG}"
   done <<< "$(grep -i '^FROM.* AS ' ${BASEDIR}/${DOCKERFILE} | awk '{print $4}')"
@@ -45,6 +47,7 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
   docker pull "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT" || true
   docker pull "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH" || true
   docker pull "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:master" || true
+  docker pull "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:main" || true
   if [ "${DOCKER_TARGET}" != "" ]; then
     DOCKER_TARGET="--target=${DOCKER_TARGET}"
   fi
@@ -56,6 +59,7 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
     --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT" \
     --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH" \
     --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:master" \
+    --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:main" \
     "${BASEDIR}"
 else
   echo "--cache-from not available with this version of Docker"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -36,6 +36,7 @@ By default, this will attempt to pull the following images, and use them as `--c
 "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT"
 "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH"
 "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:master"
+"${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:main"
 ```
 
 ## Pushing a Docker Image


### PR DESCRIPTION
This adds to the docker build command to pull caches from main in addition to master, for repos that have moved over to using a mainline branch of Main.