### PR TITLE
Alpine Docker build issues

### DIFF
--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -65,7 +65,7 @@ if ! hash pip 2>/dev/null; then
   echo Installing pip
   if [[ $PKG_MANAGER = *"apk"* ]]; then
     # shellcheck disable=SC2086
-    sudo $PKG_INSTALL py-pip python-dev
+    sudo $PKG_INSTALL py-pip python3-dev
   elif [[ $PKG_MANAGER = *"dnf"* ]]; then
     # shellcheck disable=SC2086
     sudo $PKG_INSTALL python-pip python-devel


### PR DESCRIPTION
This image is apparently built using alpine-3.14. We can [see here](https://pkgs.alpinelinux.org/packages?name=python-dev&branch=v3.14) that `python-dev` is not available in the APK of that version.

[python3-dev is available though](https://pkgs.alpinelinux.org/packages?name=python3-dev&branch=v3.14).