### PR TITLE
Pin our alpine image to a specific version

### DIFF
--- a/ci-images/alpine/Dockerfile
+++ b/ci-images/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20
+FROM docker:20.10.7
 
 USER root
 


### PR DESCRIPTION
This version uses alpine 3.13 instead of upgrading us to 3.14 which we think may have caused an issue in the orb.