### PR TITLE
Allow env vars with numbers in vault

### DIFF
--- a/orb/commands/get_vault_env.yml
+++ b/orb/commands/get_vault_env.yml
@@ -16,7 +16,7 @@ steps:
         vault kv get -format=yaml << parameters.vault_path >> > /dev/null 2>&1
         if [ $? != 0 ]; then echo "Cannot read vault path << parameters.vault_path >>" && exit 2; fi
         set -e
-        envData=($(vault kv get -format=yaml << parameters.vault_path >> | yq e '.data.data' - | sed -nr 's/([A-Z_]+): (.*)/\1=\2/ p'))
+        envData=($(vault kv get -format=yaml << parameters.vault_path >> | yq e '.data.data' - | sed -nr 's/([A-Z_0-9]+): (.*)/\1=\2/ p'))
         for i in "${envData[@]}"; do echo "export $i" >> ${BASH_ENV}; done
         source $BASH_ENV
 


### PR DESCRIPTION
**Why This PR?**
The sed command in the vault get env command was skipping any variable name with numbers in it.


**Checklist:**

* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation related to this PR