### PR TITLE
Pin Orb command-runner image to minor version

### DIFF
--- a/orb/jobs/kubernetes_e2e_tests.yml
+++ b/orb/jobs/kubernetes_e2e_tests.yml
@@ -24,7 +24,7 @@ parameters:
   command_runner_image:
     description: "The image to execute commands from against the kind cluster. Also where the script gets executed."
     type: string
-    default: "quay.io/reactiveops/ci-images:v11-alpine"
+    default: "quay.io/reactiveops/ci-images:v11.13-alpine"
   pre_script:
     description: "Script to run on the local machine before running script on command runner."
     type: string


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
The command-runner image in the orb is unpinned, unlike the rest of the images used in the orb

### What changes did you make?
pinned to 11.13

### What alternative solution should we consider, if any?

