### PR TITLE
Add optional GCP_IMG_REPO

### DIFF
--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -26,9 +26,13 @@ gcloud auth activate-service-account --configuration "rok8s-${GCP_PROJECT}" --ke
 # Set GCP Project
 gcloud config set project "${GCP_PROJECT}"
 
-# Authorize the docker client to work with GCR
-gcloud auth configure-docker --quiet
-
+if [[ -z "${GCP_IMG_REPO+x}" ]]; then
+    # Authorize the docker client to work with all default GCR repos
+    gcloud auth configure-docker --quiet
+  else
+    # Authorize the docker client to work with specified GCR repos
+    gcloud auth configure-docker "${GCP_IMG_REPO}" --quiet
+fi
 
 if [[ -z "${GCP_REGIONAL_CLUSTER+x}" ]]; then
   if [[ -z ${GCP_ZONE+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then


### PR DESCRIPTION
Add optional env var to specify an individual GCR registry to use. If left blank the GCP default is used.  

The gcp default contains the following registries. 
```
gcr.io, asia.gcr.io, eu.gcr.io, us.gcr.io
```

This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

