### PR TITLE
Add kind_config option

### DIFF
--- a/orb/commands/e2e_start_kind_cluster.yml
+++ b/orb/commands/e2e_start_kind_cluster.yml
@@ -14,6 +14,26 @@ parameters:
     default: |
       kind: Cluster
       apiVersion: kind.x-k8s.io/v1alpha4
+      kubeadmConfigPatches:
+      - |
+        apiVersion: kubeadm.k8s.io/v1beta3
+        kind: ClusterConfiguration
+        metadata:
+          name: config
+        apiServer:
+          certSANs:
+          - e2e-control-plane
+          - 127.0.0.1
+          - localhost
+        etcd:
+          serverCertSANs:
+          - e2e-control-plane
+          - 127.0.0.1
+          - localhost
+          peerCertSANs:
+          - e2e-control-plane
+          - 127.0.0.1
+          - localhost
 steps:
   - run:
       name: Start Kind Cluster

--- a/orb/jobs/kubernetes_e2e_tests.yml
+++ b/orb/jobs/kubernetes_e2e_tests.yml
@@ -21,6 +21,14 @@ parameters:
     description: "The kind node image to use.  See https://github.com/kubernetes-sigs/kind/releases"
     type: string
     default: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+  kind_config:
+    description: "A Kind config file to use for the cluster"
+    type: string
+    default: |
+      kind: Cluster
+      apiVersion: kind.x-k8s.io/v1alpha4
+      featureGates:
+        "RemoveSelfLink": false
   command_runner_image:
     description: "The image to execute commands from against the kind cluster. Also where the script gets executed."
     type: string
@@ -88,6 +96,8 @@ steps:
   - e2e_start_kind_cluster:
       kind_node_image: << parameters.kind_node_image >>
       kind_version: << parameters.kind_version >>
+      kind_config: << parameters.kind_config >>
+
   - e2e_start_command_runner:
       command_runner_image: << parameters.command_runner_image >>
   - steps: << parameters.pre_script_steps >>

--- a/orb/jobs/kubernetes_e2e_tests.yml
+++ b/orb/jobs/kubernetes_e2e_tests.yml
@@ -27,8 +27,26 @@ parameters:
     default: |
       kind: Cluster
       apiVersion: kind.x-k8s.io/v1alpha4
-      featureGates:
-        "RemoveSelfLink": false
+      kubeadmConfigPatches:
+      - |
+        apiVersion: kubeadm.k8s.io/v1beta3
+        kind: ClusterConfiguration
+        metadata:
+          name: config
+        apiServer:
+          certSANs:
+          - e2e-control-plane
+          - 127.0.0.1
+          - localhost
+        etcd:
+          serverCertSANs:
+          - e2e-control-plane
+          - 127.0.0.1
+          - localhost
+          peerCertSANs:
+          - e2e-control-plane
+          - 127.0.0.1
+          - localhost
   command_runner_image:
     description: "The image to execute commands from against the kind cluster. Also where the script gets executed."
     type: string


### PR DESCRIPTION
Do I need to change the docs anywhere?

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Support `kind_config` param for e2e tests

### What changes did you make?
Plumbed a `kind_config` param through

### What alternative solution should we consider, if any?
Maybe there's a way to dedupe the default?
