### PR TITLE
Bbensky/add gcloud auth plugin to image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
      - id: pretty-format-json
        args: ['--autofix']
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 1.10.3
+    rev: 3.0.0
     hooks:
       - id: forbid-binary
       - id: shellcheck

--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -87,10 +87,10 @@ if ! hash gcloud 2>/dev/null; then
   gcloud components update --quiet || \
     curl https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash | \
       bash -s -- --disable-prompts
-  gcloud components install gke-gcloud-auth-plugin --quiet
   ln -s "${HOME}/google-cloud-sdk/bin/gcloud" "${ROK8S_INSTALL_PATH}/gcloud"
   ln -s "${HOME}/google-cloud-sdk/bin/docker-credential-gcloud" "${ROK8S_INSTALL_PATH}/docker-credential-gcloud"
   ln -s "${HOME}/google-cloud-sdk/bin/gsutil" "${ROK8S_INSTALL_PATH}/gsutil"
+  gcloud components install gke-gcloud-auth-plugin --quiet
 fi
 
 # make sure awscli is installed

--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -87,6 +87,7 @@ if ! hash gcloud 2>/dev/null; then
   gcloud components update --quiet || \
     curl https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash | \
       bash -s -- --disable-prompts
+  gcloud components install gke-gcloud-auth-plugin --quiet
   ln -s "${HOME}/google-cloud-sdk/bin/gcloud" "${ROK8S_INSTALL_PATH}/gcloud"
   ln -s "${HOME}/google-cloud-sdk/bin/docker-credential-gcloud" "${ROK8S_INSTALL_PATH}/docker-credential-gcloud"
   ln -s "${HOME}/google-cloud-sdk/bin/gsutil" "${ROK8S_INSTALL_PATH}/gsutil"


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
This adds the gke-gcloud-auth-plugin as part of gcloud, to enable authentication between clients and GKE as required in [GKE v1.26](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke). If this is configured as a step in a deployment script, it can add to the time for jobs to run.

### What changes did you make?
The plugin is installed as part of the `install-rok8s-requirements` binary during the image build.

### What alternative solution should we consider, if any?
Users could add the install command as part of configuration steps, but that has made jobs less efficient.
