### PR TITLE
Update AWS CLI

### DIFF
--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -32,6 +32,7 @@ else
   PKG_INSTALL="${PKG_MANAGER} install -y"
 fi
 
+AWS_CLI_VERSION="${AWS_CLI_VERSION:-2.11.15}"
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.22.11}"
 HELM_VERSION="${HELM_VERSION:-v3.11.1}"
 HELM2_VERSION="${HELM2_VERSION:-v2.17.0}"
@@ -93,11 +94,9 @@ if ! hash gcloud 2>/dev/null; then
   gcloud components install gke-gcloud-auth-plugin --quiet
 fi
 
-# make sure awscli is installed
-if ! hash aws 2>/dev/null; then
-  echo Installing aws...
-  pip install awscli
-fi
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-$AWS_CLI_VERSION.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
 
 # make sure kubectl is installed
 if ! hash kubectl 2>/dev/null; then

--- a/docs/ci-images.md
+++ b/docs/ci-images.md
@@ -7,7 +7,7 @@ meta:
 
 Each new release of rok8s-scripts generates CI images for common workflows. These images include a set of common CI/CD dependencies, including Docker, Kubernetes, Helm, AWS, and Google Cloud client libraries. Starting with these images as a base for deployment workflows ensures that you don't need to spend any build time installing extra dependencies.
 
-We currently include CI Images based on Alpine and Debian Buster as our recommended starting points. The latest Debian Buster release can be pulled from `quay.io/reactiveops/ci-images:v11.15-buster`. A full list of image tags is available on our [Quay repository](https://quay.io/repository/reactiveops/ci-images).
+We currently include CI Images based on Alpine and Debian Buster as our recommended starting points. The latest Debian Buster release can be pulled from `quay.io/reactiveops/ci-images:v12.0-buster`. A full list of image tags is available on our [Quay repository](https://quay.io/repository/reactiveops/ci-images).
 
 **Deprecation Notice** As of v10 and onward, alpine and stretch will be the only available images.
 

--- a/examples/ci/bitbucket-pipelines.yml
+++ b/examples/ci/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: quay.io/reactiveops/ci-images:v11.15-buster
+image: quay.io/reactiveops/ci-images:v12.0-buster
 
 aliases:
   - &initialize-env |

--- a/examples/minimal-sops-secrets/README.md
+++ b/examples/minimal-sops-secrets/README.md
@@ -19,7 +19,7 @@ we run some of the scripts provided by rok8s-scripts. In particular, we use:
 * `k8s-deploy-and-verify` to deploy our image to Kubernetes and make sure the deployment succeeded
 	* This also calls the `k8s-deploy-secrets` script to decrypt and deploy secrets
 
-We also use the rok8s-scripts CI image, `quay.io/reactiveops/ci-images:v11.15-buster`,
+We also use the rok8s-scripts CI image, `quay.io/reactiveops/ci-images:v12.0-buster`,
 to ensure rok8s-scripts and its dependencies are available during the build and deploy jobs.
 
 ## Try it out

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -18,7 +18,7 @@ we run some of the scripts provided by rok8s-scripts. In particular, we use:
 * `prepare-kubectl` to configure the `kubectl` command to be able to deploy resources to our Kubernetes cluster
 * `k8s-deploy-and-verify` to deploy our image to Kubernetes and make sure the deployment succeeded
 
-We also use the rok8s-scripts CI image, `quay.io/reactiveops/ci-images:v11.15-buster`,
+We also use the rok8s-scripts CI image, `quay.io/reactiveops/ci-images:v12.0-buster`,
 to ensure rok8s-scripts and its dependencies are available during the build and deploy jobs.
 
 ## Try it out

--- a/orb/executors/ci-images.yml
+++ b/orb/executors/ci-images.yml
@@ -1,6 +1,6 @@
 parameters:
   version:
     type: string
-    default: "v11.15-buster"
+    default: "v12.0-buster"
 docker:
   - image: quay.io/reactiveops/ci-images:<<parameters.version>>

--- a/orb/executors/default.yml
+++ b/orb/executors/default.yml
@@ -1,6 +1,6 @@
 parameters:
   version:
     type: string
-    default: "v11.15-buster"
+    default: "v12.0-buster"
 docker:
   - image: quay.io/reactiveops/ci-images:<<parameters.version>>

--- a/orb/jobs/kubernetes_e2e_tests.yml
+++ b/orb/jobs/kubernetes_e2e_tests.yml
@@ -50,7 +50,7 @@ parameters:
   command_runner_image:
     description: "The image to execute commands from against the kind cluster. Also where the script gets executed."
     type: string
-    default: "quay.io/reactiveops/ci-images:v11.15-alpine"
+    default: "quay.io/reactiveops/ci-images:v12.0-alpine"
   pre_script:
     description: "Script to run on the local machine before running script on command runner."
     type: string


### PR DESCRIPTION
This PR fixes issues authenticating with eksctl (I hope)

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Download a specific version of the AWS CLI. I think the pip install method is deprecated? Latest docs are here: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html

### What changes did you make?
Install a specific aws-cli using curl

### What alternative solution should we consider, if any?
Unsure
