### PR TITLE
feat: remove the use of kubeval in decrypting secrets

### DIFF
--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -69,7 +69,6 @@ do
   DECRYPTED_FILE="${SOPS_SECRET_FILE}.decrypted"
   #shellcheck disable=SC2086
   sops ${SOPS_OPTIONS} --decrypt "${SOPS_SECRET_FILE}" > "${DECRYPTED_FILE}"
-  kubeval "${DECRYPTED_FILE}"
 
   kubectl replace "--namespace=${NAMESPACE}" -f "${DECRYPTED_FILE}" ||\
     kubectl create "--namespace=${NAMESPACE}" -f "${DECRYPTED_FILE}"


### PR DESCRIPTION
This PR fixes #462

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Remove the use of kubeval

### What alternative solution should we consider, if any?
We could do this with a flag, but the use of kubeval seems extraneous
anyway.